### PR TITLE
fix: integrar perfil, sesión e intereses

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/features/interested/pages/InterestedPage.jsx
+++ b/src/features/interested/pages/InterestedPage.jsx
@@ -39,7 +39,9 @@ function InterestedPage() {
     const location = useLocation();
     const [selectedCategory, setSelectedCategory] = useState(null);
     const [selectedInterests, setSelectedInterests] = useState(
-        location.state?.interests?.map((interest) => interest.id) ?? []
+        location.state?.interests?.map((interest) =>
+            typeof interest === "string" ? interest : interest.id
+        ) ?? []
     );
 
     const categories = [

--- a/src/features/profile/components/Interests.jsx
+++ b/src/features/profile/components/Interests.jsx
@@ -16,8 +16,11 @@ function Interests({ interests: savedInterests } = {}) {
 
   const interests = savedInterests?.length
     ? savedInterests.map((interest) => ({
-        name: interest.name ?? interest.label ?? interest.title,
-        icon: interest.icon ?? "•",
+        name:
+          typeof interest === "string"
+            ? interest
+            : interest.name ?? interest.label ?? interest.title,
+        icon: typeof interest === "string" ? "•" : interest.icon ?? "•",
       }))
     : defaultInterests;
 

--- a/src/features/profile/pages/EditProfilePage.jsx
+++ b/src/features/profile/pages/EditProfilePage.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import ProfileService from "../../services/ProfileService.js";
 import {
@@ -8,6 +9,7 @@ import {
 function EditProfilePage() {
     const navigate = useNavigate();
     const location = useLocation();
+    const [error, setError] = useState("");
 
     const userId = location.state?.userId ?? localStorage.getItem("waperUserId");
     const profile = location.state?.profile
@@ -18,25 +20,36 @@ function EditProfilePage() {
         : undefined;
     const interests = location.state?.interests ?? [];
 
+    useEffect(() => {
+        if (!userId) {
+            navigate("/login", { replace: true });
+        }
+    }, [navigate, userId]);
+
     const goToProfile = () => {
         navigate("/profile");
     };
 
     const saveAndGoToProfile = async (data) => {
+        setError("");
         const profileData = {
             ...data.profile,
             name: data.profile.fullName,
             interests: data.interests,
         };
 
-        let savedProfile = profileData;
+        if (!userId) return;
 
-        if (userId) {
-            try {
-                savedProfile = await ProfileService.updateProfile(userId, profileData);
-            } catch {
-                savedProfile = profileData;
+        let savedProfile;
+        try {
+            savedProfile = await ProfileService.updateProfile(userId, profileData);
+        } catch (requestError) {
+            if (requestError.status === 401) {
+                navigate("/login", { replace: true });
+                return;
             }
+            setError(requestError.message);
+            return;
         }
 
         navigate("/profile", {
@@ -60,6 +73,11 @@ function EditProfilePage() {
 
     return (
         <ProfileLayout>
+            {error && (
+                <p className="mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                    {error}
+                </p>
+            )}
             <EditProfileForm
                 onBack={goToProfile}
                 onSave={saveAndGoToProfile}

--- a/src/features/profile/pages/ProfilePage.jsx
+++ b/src/features/profile/pages/ProfilePage.jsx
@@ -23,17 +23,24 @@ function ProfilePage() {
     const userId = location.state?.userId ?? localStorage.getItem("waperUserId");
 
     useEffect(() => {
-        if (!userId) return;
+        if (!userId) {
+            navigate("/login", { replace: true });
+            return;
+        }
 
         ProfileService.getProfile(userId)
             .then((profileData) => {
                 setProfile(profileData);
                 setInterests(profileData?.interests);
             })
-            .catch(() => {
+            .catch((requestError) => {
+                if (requestError.status === 401) {
+                    navigate("/login", { replace: true });
+                    return;
+                }
                 setProfile(location.state?.profile ?? null);
             });
-    }, [location.state?.profile, userId]);
+    }, [location.state?.profile, navigate, userId]);
 
     const handleEditProfile = () => {
         navigate("/editProfile", {
@@ -45,12 +52,30 @@ function ProfilePage() {
         });
     };
 
+    const handleLogout = async () => {
+        try {
+            await ProfileService.logout();
+        } finally {
+            localStorage.removeItem("waperUserId");
+            navigate("/login", { replace: true });
+        }
+    };
+
     return (
         <ProfileLayout>
             <ProfileBackground />
             <ProfileDecorationDots />
             <div className="relative z-10 pt-10">
                 <Header onEditProfile={handleEditProfile} />
+                <div className="flex justify-end px-4">
+                    <button
+                        type="button"
+                        onClick={handleLogout}
+                        className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-[#1740FF] shadow"
+                    >
+                        Cerrar sesión
+                    </button>
+                </div>
             </div>
 
             <ProfileContent>

--- a/src/features/services/ProfileService.js
+++ b/src/features/services/ProfileService.js
@@ -1,3 +1,5 @@
+import { normalizeInterests, serializeInterests } from "./interestMapper.js";
+
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000/api";
 
 class ProfileService {
@@ -13,11 +15,31 @@ class ProfileService {
 
         const data = await ProfileService.parseResponse(response);
 
-        if (!response.ok) {
-            throw new Error(data?.message ?? "Error al comunicarse con el servidor");
+        if (response.status === 401) {
+            localStorage.removeItem("waperUserId");
         }
 
-        return data;
+        if (!response.ok) {
+            const error = new Error(
+                data?.message ?? "Error al comunicarse con el servidor"
+            );
+            error.status = response.status;
+            throw error;
+        }
+
+        if (data?.user?.interests) {
+            return {
+                ...data,
+                user: {
+                    ...data.user,
+                    interests: normalizeInterests(data.user.interests),
+                },
+            };
+        }
+
+        return data?.interests
+            ? { ...data, interests: normalizeInterests(data.interests) }
+            : data;
     }
 
     static async parseResponse(response) {
@@ -44,6 +66,12 @@ class ProfileService {
         });
     }
 
+    static logout() {
+        return ProfileService.request("/auth/logout", {
+            method: "POST",
+        });
+    }
+
     static getProfile(userId) {
         return ProfileService.request(`/users/${userId}`);
     }
@@ -51,7 +79,10 @@ class ProfileService {
     static updateProfile(userId, profileData) {
         return ProfileService.request(`/users/${userId}`, {
             method: "PUT",
-            body: JSON.stringify(profileData),
+            body: JSON.stringify({
+                ...profileData,
+                interests: serializeInterests(profileData.interests),
+            }),
         });
     }
 

--- a/src/features/services/interestMapper.js
+++ b/src/features/services/interestMapper.js
@@ -1,0 +1,29 @@
+export function normalizeInterests(interests = []) {
+    return interests.map((interest, index) => {
+        if (typeof interest === "string") {
+            return {
+                id: interest,
+                name: interest,
+                label: interest,
+            };
+        }
+
+        const name = interest.name ?? interest.label ?? interest.title ?? "";
+        return {
+            ...interest,
+            id: interest.id ?? `${name}-${index}`,
+            name,
+            label: interest.label ?? name,
+        };
+    });
+}
+
+export function serializeInterests(interests = []) {
+    return interests
+        .map((interest) =>
+            typeof interest === "string"
+                ? interest
+                : interest.name ?? interest.label ?? interest.title
+        )
+        .filter(Boolean);
+}

--- a/test/interestMapper.test.js
+++ b/test/interestMapper.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+    normalizeInterests,
+    serializeInterests,
+} from "../src/features/services/interestMapper.js";
+
+test("normalizes stored strings for the UI", () => {
+    assert.deepEqual(normalizeInterests(["Programación"]), [
+        {
+            id: "Programación",
+            name: "Programación",
+            label: "Programación",
+        },
+    ]);
+});
+
+test("serializes UI objects for Spring and Mongo", () => {
+    assert.deepEqual(
+        serializeInterests([
+            { id: 701, name: "Programación" },
+            { id: 401, label: "Running" },
+        ]),
+        ["Programación", "Running"],
+    );
+});


### PR DESCRIPTION
## Qué cambia
- conecta registro, login, perfil y edición con el BFF
- normaliza intereses entre strings de Mongo y objetos de UI
- muestra errores reales de guardado
- redirige al login cuando expira la sesión
- agrega logout y limpieza del estado local
- añade pruebas del mapeo de intereses

## Motivo
La web ocultaba errores, asumía formatos incompatibles para intereses y podía navegar a pantallas privadas sin una sesión válida.

## Impacto
El flujo de usuario queda coherente con el BFF y la API, sin modificar el comportamiento acordado de la imagen de perfil.

## Verificación
- `npm test` (2/2)
- `npm run lint`
- `npm run build`
